### PR TITLE
Enforce (dll|exe)$ for IsBounceExecutable

### DIFF
--- a/Bounce.Framework/BounceRunner.cs
+++ b/Bounce.Framework/BounceRunner.cs
@@ -76,7 +76,7 @@ namespace Bounce.Framework {
         private bool IsBounceExecutable(string path) {
             string fileName = Path.GetFileName(path);
             return !fileName.Equals("Bounce.Framework.dll", StringComparison.InvariantCultureIgnoreCase)
-                && new Regex(@"\bbounce\b.*\.(dll|exe)", RegexOptions.IgnoreCase).IsMatch(fileName);
+                && new Regex(@"\bbounce\b.*\.(dll|exe)$", RegexOptions.IgnoreCase).IsMatch(fileName);
         }
     }
 }


### PR DESCRIPTION
This is related to #17

From https://github.com/refractalize/bounce/blob/master/README.md, 

> Ensure your project produces an assembly ending with ".Bounce.dll" or an executable ending with ".Bounce.exe" (both case-insensitive). Bounce only looks for tasks in these assemblies, so that it can start up really quickly.

This enforces that behavior by updating the regex in `IsBounceExecutable`.

Not sure how to test this change. Any advice?
