### PR TITLE
Support for newer versions of MSBuild

### DIFF
--- a/Bounce.Console.Tests/BeforeBounceFeature/BeforeBounceFeature/BeforeBounceFeature.csproj
+++ b/Bounce.Console.Tests/BeforeBounceFeature/BeforeBounceFeature/BeforeBounceFeature.csproj
@@ -63,7 +63,7 @@
   <ItemGroup>
     <Reference Include="Bounce.Framework">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Bounce.Framework.dll</HintPath>
+      <HintPath>..\..\..\Bounce.Framework\bin\Debug\Bounce.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Bounce.Framework.Tests">
       <SpecificVersion>False</SpecificVersion>

--- a/Bounce.Framework.Tests/Bounce.Framework.Tests.csproj
+++ b/Bounce.Framework.Tests/Bounce.Framework.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TaskRunnerTests.cs" />
     <Compile Include="TasksForTaskNames.cs" />
+    <Compile Include="VisualStudio\MsBuildPathDiscoveryTests.cs" />
     <Compile Include="VisualStudio\ProjectFilePropertyExpressionParserTest.cs" />
     <Compile Include="Web\WebSiteBindingParserTest.cs" />
   </ItemGroup>

--- a/Bounce.Framework.Tests/VisualStudio/MsBuildPathDiscoveryTests.cs
+++ b/Bounce.Framework.Tests/VisualStudio/MsBuildPathDiscoveryTests.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Remoting.Messaging;
+using System.Text;
+using Bounce.Framework.VisualStudio;
+using NUnit.Framework;
+
+namespace Bounce.Framework.Tests.VisualStudio
+{
+    [TestFixture]
+    class MsBuildPathDiscoveryTests {
+        private MsBuildPathDiscovery Discoverer;
+
+        [SetUp]
+        public void SetUp() {
+            Discoverer = new MsBuildPathDiscovery();
+            Discoverer.MsBuildLocations.Clear();
+            Discoverer.MsBuildLocations.Add("c:\\msbuild.exe");
+            Discoverer.MsBuildLocations.Add("c:\\other\\place\\msbuild.exe");
+        }
+
+        [Test]
+        public void FindsLatestMsBuildWhenExistsCheckPasses() {
+            Discoverer.FileExitsCheck = s => true;
+
+            var path = Discoverer.LocateMostRecentMsBuildPath();
+
+            Assert.That(path, Is.EqualTo("c:\\msbuild.exe"));
+        }
+
+        [Test]
+        public void ReturnsFallbackForBackwardsCompatabilityIfItCantFindAnything() {
+            Discoverer.FileExitsCheck = s => false;
+
+            var path = Discoverer.LocateMostRecentMsBuildPath();
+
+            Assert.That(path, Is.EqualTo("c:\\other\\place\\msbuild.exe"));
+        }
+
+        [Test]
+        public void MsBuildLocationsPopulatedWithEnvVariableIfAvailable() {
+            Environment.SetEnvironmentVariable("MSBuild", "c:\\msbuild.exe");
+
+            Discoverer = new MsBuildPathDiscovery();
+
+            Assert.That(Discoverer.MsBuildLocations[0], Is.EqualTo("c:\\msbuild.exe"));
+        }
+
+        [Test]
+        public void MsBuildLocationsFiltersOutNoneExistentPlaceholder() {
+            Discoverer = new MsBuildPathDiscovery();
+
+            Assert.That(Discoverer.MsBuildLocations[0], Is.Not.EqualTo("%MSBuild%"));
+        }
+    }
+}

--- a/Bounce.Framework.Tests/VisualStudio/MsBuildPathDiscoveryTests.cs
+++ b/Bounce.Framework.Tests/VisualStudio/MsBuildPathDiscoveryTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.Remoting.Messaging;
 using System.Text;
 using Bounce.Framework.VisualStudio;
+using Moq;
 using NUnit.Framework;
 
 namespace Bounce.Framework.Tests.VisualStudio
@@ -11,10 +12,18 @@ namespace Bounce.Framework.Tests.VisualStudio
     [TestFixture]
     class MsBuildPathDiscoveryTests {
         private MsBuildPathDiscovery Discoverer;
+        private Mock<IFileSystemWrapper> FsMock;
+        private List<string> FileSystemContents;
 
         [SetUp]
         public void SetUp() {
-            Discoverer = new MsBuildPathDiscovery();
+            FileSystemContents = new List<string>();
+
+            FsMock = new Mock<IFileSystemWrapper>();
+            FsMock.Setup(x => x.FileExists(It.IsAny<string>())).Returns((string s) => FileSystemContents.Contains(s));
+            FsMock.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns((string s) => FileSystemContents.Contains(s));
+
+            Discoverer = new MsBuildPathDiscovery(FsMock.Object);
             Discoverer.MsBuildLocations.Clear();
             Discoverer.MsBuildLocations.Add("c:\\msbuild.exe");
             Discoverer.MsBuildLocations.Add("c:\\other\\place\\msbuild.exe");
@@ -22,18 +31,18 @@ namespace Bounce.Framework.Tests.VisualStudio
 
         [Test]
         public void FindsLatestMsBuildWhenExistsCheckPasses() {
-            Discoverer.FileExitsCheck = s => true;
+            FileSystemContents.Add("c:\\msbuild.exe");
 
-            var path = Discoverer.LocateMostRecentMsBuildPath();
+            string path = Discoverer.LocateMostRecentMsBuildPath();
 
             Assert.That(path, Is.EqualTo("c:\\msbuild.exe"));
         }
 
         [Test]
         public void ReturnsFallbackForBackwardsCompatabilityIfItCantFindAnything() {
-            Discoverer.FileExitsCheck = s => false;
+            FileSystemContents.Clear();
 
-            var path = Discoverer.LocateMostRecentMsBuildPath();
+            string path = Discoverer.LocateMostRecentMsBuildPath();
 
             Assert.That(path, Is.EqualTo("c:\\other\\place\\msbuild.exe"));
         }
@@ -42,16 +51,33 @@ namespace Bounce.Framework.Tests.VisualStudio
         public void MsBuildLocationsPopulatedWithEnvVariableIfAvailable() {
             Environment.SetEnvironmentVariable("MSBuild", "c:\\msbuild.exe");
 
-            Discoverer = new MsBuildPathDiscovery();
-
             Assert.That(Discoverer.MsBuildLocations[0], Is.EqualTo("c:\\msbuild.exe"));
         }
 
         [Test]
         public void MsBuildLocationsFiltersOutNoneExistentPlaceholder() {
-            Discoverer = new MsBuildPathDiscovery();
+            FileSystemContents.Add("c:\\msbuild.exe");
 
             Assert.That(Discoverer.MsBuildLocations[0], Is.Not.EqualTo("%MSBuild%"));
+        }
+
+        [Test]
+        public void ReturnsScannedLocationsWithResult() {
+            Discoverer = new MsBuildPathDiscovery(FsMock.Object);
+
+            var path = Discoverer.LocateMostRecentMsBuildPath();
+
+            Assert.That(path.SearchLocations, Is.Not.Empty);
+        }
+
+        [Test]
+        public void LookupLocationsTracked() {
+            Discoverer = new MsBuildPathDiscovery(FsMock.Object);
+            FileSystemContents.Add("C:\\Program Files (x86)\\MSBuild\\14.0\\Bin\\msbuild.exe");
+
+            var path = Discoverer.LocateMostRecentMsBuildPath();
+
+            Assert.That(path.SearchLocations, Is.Not.Empty);
         }
     }
 }

--- a/Bounce.Framework/Bounce.Framework.csproj
+++ b/Bounce.Framework/Bounce.Framework.csproj
@@ -115,6 +115,7 @@
     <Compile Include="VisualStudio\IMsBuildFile.cs" />
     <Compile Include="VisualStudio\IVisualStudioProject.cs" />
     <Compile Include="VisualStudio\MsBuild.cs" />
+    <Compile Include="VisualStudio\MsBuildPathDiscovery.cs" />
     <Compile Include="VisualStudio\MsBuildFile.cs" />
     <Compile Include="Web\IAppPool.cs" />
     <Compile Include="Web\Iis7WebApplication.cs" />

--- a/Bounce.Framework/VisualStudio/MsBuild.cs
+++ b/Bounce.Framework/VisualStudio/MsBuild.cs
@@ -9,7 +9,7 @@ namespace Bounce.Framework.VisualStudio {
 
         public MsBuild(IShell shell) {
             Shell = shell;
-            MsBuildExe = Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe");
+            MsBuildExe = new MsBuildPathDiscovery().LocateMostRecentMsBuildPath();
         }
 
         public void Build(string projSln, string config, string outputDir, string target)

--- a/Bounce.Framework/VisualStudio/MsBuildPathDiscovery.cs
+++ b/Bounce.Framework/VisualStudio/MsBuildPathDiscovery.cs
@@ -7,15 +7,18 @@ namespace Bounce.Framework.VisualStudio {
     class MsBuildPathDiscovery {
 
         public Func<string, bool> FileExitsCheck { get; set; }
-        public readonly List<string> MsBuildLocations = new List<string> {
-            Environment.ExpandEnvironmentVariables(@"%MSBuild%"),
-            Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\MSBuild\14.0\Bin\msbuild.exe"),
-            Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\MSBuild\12.0\Bin\msbuild.exe"),
-            Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe")
-        };
+        public readonly List<string> MsBuildLocations;
 
         public MsBuildPathDiscovery(Func<string, bool> fileExitsCheck = null) {
             FileExitsCheck = fileExitsCheck ?? File.Exists;
+
+            MsBuildLocations = new List<string> {
+                Environment.ExpandEnvironmentVariables(@"%MSBuild%"),
+                Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\MSBuild\14.0\Bin\msbuild.exe"),
+                Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\MSBuild\12.0\Bin\msbuild.exe"),
+                Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe")
+            };
+
             if (MsBuildLocations.First() == "%MSBuild%") {
                 MsBuildLocations.RemoveAt(0);
             }

--- a/Bounce.Framework/VisualStudio/MsBuildPathDiscovery.cs
+++ b/Bounce.Framework/VisualStudio/MsBuildPathDiscovery.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Bounce.Framework.VisualStudio {
+    class MsBuildPathDiscovery {
+
+        public Func<string, bool> FileExitsCheck { get; set; }
+        public readonly List<string> MsBuildLocations = new List<string> {
+            Environment.ExpandEnvironmentVariables(@"%MSBuild%"),
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\MSBuild\14.0\Bin\msbuild.exe"),
+            Environment.ExpandEnvironmentVariables(@"%ProgramFiles%\MSBuild\12.0\Bin\msbuild.exe"),
+            Environment.ExpandEnvironmentVariables(@"%SystemRoot%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe")
+        };
+
+        public MsBuildPathDiscovery(Func<string, bool> fileExitsCheck = null) {
+            FileExitsCheck = fileExitsCheck ?? File.Exists;
+            if (MsBuildLocations.First() == "%MSBuild%") {
+                MsBuildLocations.RemoveAt(0);
+            }
+        }
+
+        public string LocateMostRecentMsBuildPath() {
+            foreach (var location in MsBuildLocations) {
+                if (FileExitsCheck(location)) {
+                    return location;
+                }
+            }
+            return MsBuildLocations.Last();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds tested support for detecting the latest installed versions of MSBuild when Bounce executes an MSBuild task.

It searches multiple locations:
- %SystemDrive%\Program Files\MSBuild\14.0\Bin\msbuild.exe
- %SystemDrive%\Program Files (x86)\MSBuild\14.0\Bin\msbuild.exe
- %SystemDrive%\Program Files\MSBuild\12.0\Bin\msbuild.exe
- %SystemDrive%\Program Files (x86)\MSBuild\12.0\Bin\msbuild.exe
- %SystemDrive%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe

Additionally, if an environmental variable is provided called %MSBuild%, that'll take precedence for any specific required behaviour (or, I suppose, forwards compatibility).

Tried to stick to the house style. Do let me know if I missed with something.

Tests provided - I'm aware this project isn't particularly active right now, but I wanted to throw this across to do the right thing <3
- D
